### PR TITLE
Create docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,12 +28,13 @@ jobs:
           python-version: 3.9
       - id: pages
         uses: actions/configure-pages@v4
-      - name: Create virtualenv
-        run: |
-          python3 -m venv ~/venv
-          echo "source ~/venv/bin/activate" >> $BASH_ENV
       - name: Install requirements
-        run: poetry install --extras docs --no-interaction --verbose --no-ansi
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          poetry install --extras docs --no-interaction --verbose --no-ansi
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
       - name: Make docs
         run: |
           cd docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
+          curl -sSL https://install.python-poetry.org | python -
+          poetry config virtualenvs.create false
           poetry install --extras docs --no-interaction --verbose --no-ansi
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Publish Docs
+
+on:
+  workflow_dispatch: # allow manual runs
+  push:
+    branches:
+      - master
+    paths: # avoid extra builds
+      - docs/**
+      - .github/workflows/docs.yml
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false # skip any intermediate builds but let finish
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - id: pages
+        uses: actions/configure-pages@v4
+      - name: Create virtualenv
+        run: |
+          python3 -m venv ~/venv
+          echo "source ~/venv/bin/activate" >> $BASH_ENV
+      - name: Install requirements
+        run: poetry install --extras docs --no-interaction --verbose --no-ansi
+      - name: Make docs
+        run: |
+          cd docs
+          make html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
1. migrate to deployment env
2. add poetry to runner
3. skip creating another venv
4. ~contemplate extras only or separate caching~

TODO:
- [x] publish
- [x] verify autodocs
- [ ] remove (unused?) sphinxcontrib.httpdomain?
- [x] version, year
- [x] remove from circle config — keep build for integrations, only remove publish?
- [ ] check depending tests etc. on docs built
- [ ] remove gh-pages yarn package, command and workflow/branch